### PR TITLE
adminを削除、管理者ユーザーに広告作成を表示

### DIFF
--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -19,6 +19,7 @@
       <div class="nav-flex">
         <v-list dense nav>
           <template v-if="userData.is_manager">
+
             <v-list-item :to="{ path: 'center', query: { cid: followingId } }">
               <v-list-item-icon>
                 <v-icon>mdi-home-variant</v-icon>
@@ -27,6 +28,16 @@
                 <v-list-item-title>管理者ページ</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
+
+            <v-list-item v-bind="{ to: '/new_post' }" link>
+              <v-list-item-icon>
+                <v-icon>mdi-pencil</v-icon>
+              </v-list-item-icon>
+              <v-list-item-content>
+                <v-list-item-title>投稿を作成</v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+
             <v-list-item v-bind="{ to: '/new_ad' }" link>
               <v-list-item-icon>
                 <v-icon>mdi-clipboard-plus</v-icon>
@@ -35,6 +46,7 @@
                 <v-list-item-title>広告を作成</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
+
           </template>
           <v-list-item
             v-for="item in drawerItems"

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -12,7 +12,6 @@ let state = {
   userData: {
     id: null,
     is_manager: null,
-    admin: false,
     following: {
       id: null
     }
@@ -44,7 +43,6 @@ let getters = {
   loggedIn:        state => state.loggedIn,
   signedUp:        state => state.signedUp,
   userId:          state => state.userData.id,
-  admin:           state => state.userData.admin,
   isLoading:       state => state.isLoading,
   followingId:     state => {
     if (state.userData) {
@@ -56,7 +54,7 @@ let getters = {
 }
 
 const actions = {
-  // main.jsで最初に呼び出され、localStorageにuserDataがあればそれを取り出してログイン状態を作る
+  // hello_vue.jsで最初に呼び出され、localStorageにuserDataがあればそれを取り出してログイン状態を作る
   autoLogin ({ commit }) {
     let userId = localStorage.getItem('userId')
     if (userId) {

--- a/app/javascript/views/Top.vue
+++ b/app/javascript/views/Top.vue
@@ -27,6 +27,13 @@
       <h2 class="font-maru">{{ pageData.name }}</h2>
       <TimeLine />
     </template>
+
+    <!-- 管理者専用 -->
+
+    <template v-if="userData.email == 'viscomi10440@gmail.com'">
+      <Link path="/new_ad" name="広告を作成" icon="mdi-clipboard-plus" />
+    </template>
+
   </div>
 </template>
 
@@ -39,7 +46,7 @@ export default {
       name: null
     }
   }),
-  computed: mapGetters(["signedUp", "loggedIn"]),
+  computed: mapGetters(["signedUp", "userData", "loggedIn"]),
   mounted () {
     if (this.loggedIn) {
       this.$axios.get('/community_center').then(res => {

--- a/app/views/api/v1/community_centers/create.json.jbuilder
+++ b/app/views/api/v1/community_centers/create.json.jbuilder
@@ -1,3 +1,3 @@
 json.userData do
-  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
 end

--- a/app/views/api/v1/community_centers/update.json.jbuilder
+++ b/app/views/api/v1/community_centers/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.userData do
-  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
 end

--- a/app/views/api/v1/sessions/create.json.jbuilder
+++ b/app/views/api/v1/sessions/create.json.jbuilder
@@ -1,10 +1,10 @@
 if !@user.is_manager
   json.userData do
-    json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+    json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
   end
 else
   json.userData do
-    json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+    json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
   end
   json.comData do
     json.extract! @user.community_center, :id, :name, :comment, :user_id

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following

--- a/app/views/api/v1/users/update.json.jbuilder
+++ b/app/views/api/v1/users/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.userData do
-  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :admin
+  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -114,6 +114,13 @@ ad_params = [
   end
 end
 
+user = User.create!(
+  name: '管理者アカウント',
+  email: 'viscomi10440@gmail.com',
+  password: ENV['MANAGE_PASS'],
+  activated: true
+)
+
 AdminUser.create!(
   email: 'viscomi10440@gmail.com', 
   password: ENV['MANAGE_PASS'], 


### PR DESCRIPTION
- テストでの利便性とポートフォリオとしての閲覧を想定して、公民館ユーザーからも「広告を作成」を可能にしているが、運用を開始したらリンクを削除して、アクセスをブロックする