### PR TITLE
メーラー挙動の修正、メール配信解除

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -25,12 +25,16 @@ class Api::V1::UsersController < ApiController
   def update
     id = CommunityCenter.find_by(name: params[:follow]).id
     @user = current_user
-    response_bad_request unless @user.update(name: params[:name]) && @user.subscription.update(community_center_id: id)
+    response_bad_request unless @user.update(update_user_params) && @user.subscription.update(community_center_id: id)
   end
 
   private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password)
+      params.require(:user).permit(:name, :email, :password, :mute_notification)
+    end
+
+    def update_user_params
+      params.require(:user).permit(:name, :mute_notification)
     end
 end

--- a/app/javascript/components/Send.vue
+++ b/app/javascript/components/Send.vue
@@ -23,7 +23,6 @@
 </template>
 
 <script>
-import { mapMutations } from 'vuex'
 export default {
   props: {
     contactId: {
@@ -36,18 +35,14 @@ export default {
     }
   },
   methods: {
-    ...mapMutations(['updateIsLoading']),
     onClick () {
       this.sentAt = 'now'
-      this.updateIsLoading(true)
       this.$axios.post(`/contact_send/${this.contactId}`).then(res => {
         this.sentAt = res.data.sent_at
-        this.updateIsLoading(false)
         this.$emit('sent', res.data.sent_at)
         location.reload()
       }).catch(() => {
         this.sentAt = null
-        this.updateIsLoading(false)
       })
     }
   }

--- a/app/javascript/components/form/Input.vue
+++ b/app/javascript/components/form/Input.vue
@@ -38,6 +38,13 @@
       :disabled="disabled"
       @blur="onBlur"
     ></v-select>
+
+    <v-checkbox
+      v-if="type === 'checkbox'"
+      v-model="inputValue"
+      :label="label"
+      @click="onBlur"
+    ></v-checkbox>
   </div>
 </template>
 
@@ -57,7 +64,6 @@ export default {
       default: false
     },
     value: {
-      type: String,
       default: null
     },
     before: {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -14,7 +14,8 @@ let state = {
     is_manager: null,
     following: {
       id: null
-    }
+    },
+    mute_notification: false
   },
   // いずれかのユーザーがログインしているか
   loggedIn: false,

--- a/app/javascript/stylesheets/styles.scss
+++ b/app/javascript/stylesheets/styles.scss
@@ -295,9 +295,9 @@
 }
 
 @media (max-width: 600px) {
-  .tabs-container {
-    // transform: translateX(-30px);
-  }
+  // .tabs-container {
+  //   // transform: translateX(-30px);
+  // }
 }
 
 //---------------- Ad.vue ----------------//

--- a/app/javascript/views/EditMyPage.vue
+++ b/app/javascript/views/EditMyPage.vue
@@ -15,6 +15,13 @@
         :items="coms"
         :disabled="isManager"
         @input="form.follow = $event" />
+      <Input
+        label="公民館からのメールでの連絡を受け取る"
+        type="checkbox"
+        before
+        :value="form.mute_notification"
+        @input="form.mute_notification = $event" />
+      <p class="text-left grey--text">公民館からのメールは、ご登録のメールアドレスに送信されます。</p>
       <Button value="変更を保存" @click="onSubmit" />
     </v-form>
   </div>
@@ -41,7 +48,8 @@ export default {
     form () {
       return {
         name: this.userData.name,
-        follow: this.userData.following.name
+        follow: this.userData.following.name,
+        mute_notification: this.userData.mute_notification
       }
     },
     isManager () {
@@ -51,6 +59,7 @@ export default {
   methods: {
     ...mapActions(["editProfile"]),
     onSubmit () {
+      console.log(this.form.mute_notification)
       if (this.form.name && this.form.follow) {
         this.$store.dispatch('editProfile', this.form)
       } else {

--- a/app/javascript/views/SignUp.vue
+++ b/app/javascript/views/SignUp.vue
@@ -24,6 +24,13 @@
         type="select"
         :items="coms"
         @input="follow = $event" />
+      <Input
+        label="公民館からのメールでの連絡を受け取る"
+        type="checkbox"
+        before
+        :value="form.mute_notification"
+        @input="form.mute_notification = $event" />
+      <p class="text-left grey--text">公民館からのメールは、ご登録のメールアドレスに送信されます。</p>
       <Alert :showAlert="showAlert.term" comment="ご利用いただくには、利用規約に同意していただく必要があります。" />
       <Term
         :dialog="dialog"
@@ -49,6 +56,7 @@ export default {
       name: '',
       email: '',
       password: '',
+      mute_notification: ''
     },
     follow: '',
     password_conf: '',
@@ -59,11 +67,6 @@ export default {
     },
     openTerm: false,
     coms: [],
-    emailRules: [
-      v => !!v || '必須項目です',
-      v => /.+@.+/.test(v) || 'メールアドレスの形式が正しくありません'
-    ],
-    nameRule: [v => !!v || '必須項目です'],
     dialog: false
   }),
   computed: {

--- a/app/models/community_center.rb
+++ b/app/models/community_center.rb
@@ -21,6 +21,7 @@ class CommunityCenter < ApplicationRecord
 
   def send_contact(contact)
     followers.each do |follower|
+      next if follower.mute_notification
       CommunityCenterMailer.contact(contact, follower).deliver_now
     end
   end

--- a/app/views/api/v1/users/index.json.jbuilder
+++ b/app/views/api/v1/users/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @users, :name, :email

--- a/app/views/api/v1/users/show.json.jbuilder
+++ b/app/views/api/v1/users/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
+json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :mute_notification

--- a/app/views/api/v1/users/update.json.jbuilder
+++ b/app/views/api/v1/users/update.json.jbuilder
@@ -1,3 +1,3 @@
 json.userData do
-  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following
+  json.extract! @user, :id, :name, :email, :is_manager, :community_center_id, :following, :mute_notification
 end


### PR DESCRIPTION
- サインアップ、編集画面にuser.mute_notificationカラムと紐づいたチェックボックスを配置、メール配信解除が可能
- フロントからmute_notificationを送って設定し、フロントでmute_notificationを受け取れるようAPIを修正
- mute_notification == trueのとき、メールを送信をスキップ
- メール送信処理中、isLoadingをtrueにせず、処理中ステータスのみ表示