### PR TITLE
Dev

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::UsersController < ApiController
   private
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :mute_notification)
+      params.require(:user).permit(:name, :email, :password)
     end
 
     def update_user_params

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -20,7 +20,7 @@
         <v-list dense nav>
           <template v-if="userData.is_manager">
 
-            <v-list-item :to="{ path: 'center', query: { cid: followingId } }">
+            <v-list-item :to="{ path: '/center', query: { cid: followingId } }">
               <v-list-item-icon>
                 <v-icon>mdi-home-variant</v-icon>
               </v-list-item-icon>

--- a/app/javascript/views/SignUp.vue
+++ b/app/javascript/views/SignUp.vue
@@ -24,13 +24,6 @@
         type="select"
         :items="coms"
         @input="follow = $event" />
-      <Input
-        label="公民館からのメールでの連絡を受け取る"
-        type="checkbox"
-        before
-        :value="form.mute_notification"
-        @input="form.mute_notification = $event" />
-      <p class="text-left grey--text">公民館からのメールは、ご登録のメールアドレスに送信されます。</p>
       <Alert :showAlert="showAlert.term" comment="ご利用いただくには、利用規約に同意していただく必要があります。" />
       <Term
         :dialog="dialog"
@@ -56,7 +49,6 @@ export default {
       name: '',
       email: '',
       password: '',
-      mute_notification: ''
     },
     follow: '',
     password_conf: '',


### PR DESCRIPTION
- Navbarの「管理者ページ」のパスを path="center" から path="/center" と明示することで、/contactsから一つ上のrouteに帰れる様に修正
- SignUpをできる限りシンプルに保つために、mute_notificationの項目を削除
-