### PR TITLE
Feature/users list

### DIFF
--- a/app/controllers/api/v1/ads_controller.rb
+++ b/app/controllers/api/v1/ads_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::AdsController < ApiController
   before_action :authenticate_user?, only: %i[create image]
 
+  def index
+    response_bad_request unless current_user.is_manager
+    @ads = current_user.community_center.ads
+  end
+
   def create
     ad = Ad.create(ad_params)
     community_centers = params[:community_centers]

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::PostsController < ApiController
   before_action :authenticate_user?, only: %i[show create updatedestroy image]
 
+  def index
+    response_bad_request unless current_user.is_manager
+    @posts = current_user.community_center.posts
+  end
+
   def show
     @post = Post.find_by!(id: params[:id])
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,11 @@
 class Api::V1::UsersController < ApiController
-  before_action :authenticate_user?, only: %i[show update destroy]
+  before_action :authenticate_user?, only: %i[index show update destroy]
   before_action :correct_user?, only: %i[show update destroy]
+
+  def index
+    response_bad_request unless current_user.is_manager
+    @users = current_user.community_center.followers
+  end
 
   def show
     @user = current_user

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -43,7 +43,7 @@
                 <v-icon>mdi-clipboard-plus</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
-                <v-list-item-title>広告を作成</v-list-item-title>
+                <v-list-item-title>広告を作成（仮置）</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
 
@@ -52,7 +52,7 @@
                 <v-icon>mdi-email</v-icon>
               </v-list-item-icon>
               <v-list-item-content>
-                <v-list-item-title>メールを送信</v-list-item-title>
+                <v-list-item-title>メール管理</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
 

--- a/app/javascript/components/Post.vue
+++ b/app/javascript/components/Post.vue
@@ -6,7 +6,7 @@
       @click="modal = true"
     >
       <div class="tool-wrapper">
-        <v-menu offset-y absolute right v-if="isManager">
+        <v-menu offset-y absolute right v-if="isManager && isManagePage">
           <template v-slot:activator="{ on, attrs }">
             <v-icon
               class="icon"
@@ -105,6 +105,9 @@ export default {
     },
     isManager () {
       return this.userData.is_manager
+    },
+    isManagePage () {
+      return !!this.$route.query.cid
     },
     n () {
       return Math.floor(Math.random() * Math.floor(3))

--- a/app/javascript/components/TimeLine.vue
+++ b/app/javascript/components/TimeLine.vue
@@ -34,17 +34,19 @@ export default {
   }),
   computed: {
     shuffledAds () {
-      let result = []
-      for (let i = 0; i < this.ads.length; i++) {
-        let n = Math.floor(Math.random() * Math.floor(2))
-        if (n === 0) {
-          result.push(this.ads[i])
-        } else {
-          result.unshift(this.ads[i])
-        }
-      }
-      this.ads =  result
-      return result
+      // 広告の表示順をシャッフルするメソッド
+      // 仕様未決定のため保留
+      // let result = []
+      // for (let i = 0; i < this.ads.length; i++) {
+      //   let n = Math.floor(Math.random() * Math.floor(2))
+      //   if (n === 0) {
+      //     result.push(this.ads[i])
+      //   } else {
+      //     result.unshift(this.ads[i])
+      //   }
+      // }
+      // this.ads =  result
+      return this.ads
     }
   },
   watch: {

--- a/app/javascript/views/CommunityCenter.vue
+++ b/app/javascript/views/CommunityCenter.vue
@@ -1,20 +1,108 @@
 <template>
   <div id="com-page-container">
     <div v-show="isManager" class="link-container">
-      <div class="to-edit" @click="toEdit">
-        <v-icon large>mdi-account-cog</v-icon>
+      <div class="to-edit">
+        <router-link :to="{ path: 'edit_com', query: { cid: cid } }">
+          <v-icon large>mdi-account-cog</v-icon>
+        </router-link>
       </div>
       <div class="to-new">
         <Link path="/new_post" name="投稿を作成" icon="mdi-pencil" />
       </div>
     </div>
-    <h2 class="pb-3">{{ communityCenter.name }}</h2>
-    <p>{{ communityCenter.comment }}</p>
-    <v-img
-      src="/images/community_center.png"
-      height="150px"
-    ></v-img>
-    <TimeLine />
+    <section id="info" class="text-left ml-10 my-5">
+      <h2 class="pb-3">{{ communityCenter.name }}</h2>
+      <p>管理者：{{ communityCenter.user.name }}</p>
+    </section>
+
+    <v-expansion-panels
+      v-model="panel"
+      multiple
+    >
+      <v-expansion-panel>
+        <v-expansion-panel-header @click="getPosts">投稿一覧</v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <div
+            v-for="post in posts"
+            class="post"
+            :key="post.id">
+            <Post :post="post" :key="post.id" />
+          </div>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-header @click="getAds">登録されている広告</v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-row>
+            <v-col
+              cols=12 sm=6 lg=4
+              v-for="ad in ads"
+              class="ad"
+              :key="ad.phone_number">
+              <Ad :ad="ad" :key="ad.phone_number" />
+            </v-col>
+          </v-row>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-header @click="getContacts">メール</v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <Alert :showAlert="true" type="info" comment="この画面ではメールの確認しかできません。メールを作成したり、編集、送信したい場合は、サイドバーの「メール管理」から操作してください。" />
+          <template v-for="contact in contacts">
+            <v-card :key="contact.id" class="px-4 text-left">
+              <v-row>
+                <v-card-title>件名：{{ contact.subject }}</v-card-title>
+              </v-row>
+              <v-row class="gray--text">
+                <v-card-text>
+                  <p>本文</p>
+                  <p style="white-space: pre-wrap;">{{ contact.content }}</p>
+                </v-card-text>
+              </v-row>
+              <v-row>
+                <v-card-text class="grey--text">
+                  <p v-if="contact.sent_at_formatted">送信済：{{ contact.sent_at_formatted }}</p>
+                  <p v-else>未送信（最終更新日：{{ contact.updated_at_formatted }}）</p>
+                </v-card-text>
+              </v-row>
+            </v-card>
+            <v-divider :key="contact.subject" class="mb-6"></v-divider>
+          </template>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+
+      <v-expansion-panel>
+        <v-expansion-panel-header @click="getFollowers">登録者一覧</v-expansion-panel-header>
+        <v-expansion-panel-content class="text-left">
+          <v-virtual-scroll
+            :items="followers"
+            :item-height="70"
+            height="400">
+            <template v-slot:default="{ item }">
+              <v-list-item>
+                <v-list-item-avatar>
+                  <v-avatar
+                    color="red lighten-3"
+                    size="56"
+                    class="white--text">
+                    {{ item.initial }}
+                  </v-avatar>
+                </v-list-item-avatar>
+
+                <v-list-item-content>
+                  <v-list-item-title>{{ item.name }}</v-list-item-title>
+                  <p>{{ item.email }}</p>
+                </v-list-item-content>
+                <v-icon v-if="!item.mute_contact">mdi-email</v-icon>
+              </v-list-item>
+            </template>
+          </v-virtual-scroll>
+          <p class="mt-5"><v-icon>mdi-email</v-icon>アイコンがついていないユーザーは、メール配信設定をオフにしています。</p>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
   </div>
 </template>
 
@@ -26,7 +114,13 @@ export default {
     communityCenter: {
       name: null,
       comment: null
-    }
+    },
+    panel: [],
+    readonly: false,
+    posts: [],
+    ads: [],
+    contacts: [],
+    followers: []
   }),
   computed: {
     ...mapGetters(['userData']),
@@ -41,12 +135,29 @@ export default {
     this.$axios.get(`/community_centers/${this.cid}`).then(res => {
       this.communityCenter = res.data
     }).catch(() => {
-      alert('エラーが発生しました。再度お試しください。')
+      this.$router.push('/')
     })
   },
   methods: {
-    toEdit () {
-      this.$router.push('/edit_com')
+    getPosts () {
+      this.$axios.get('/posts').then(res => {
+        this.posts = res.data
+      })
+    },
+    getAds () {
+      this.$axios.get('/ads').then(res => {
+        this.ads = res.data
+      })
+    },
+    getContacts () {
+      this.$axios.get('/contacts').then(res => {
+        this.contacts = res.data
+      })
+    },
+    getFollowers () {
+      this.$axios.get('/users').then(res => {
+        this.followers = res.data
+      })
     }
   }
 }

--- a/app/javascript/views/CommunityCenter.vue
+++ b/app/javascript/views/CommunityCenter.vue
@@ -7,7 +7,7 @@
         </router-link>
       </div>
       <div class="to-new">
-        <Link path="/new_post" name="投稿を作成" icon="mdi-pencil" />
+        <Link path="/new_post" name="投稿を作成" icon="mdi-plus" />
       </div>
     </div>
     <section id="info" class="text-left ml-10 my-5">

--- a/app/javascript/views/Contacts/Contacts.vue
+++ b/app/javascript/views/Contacts/Contacts.vue
@@ -1,7 +1,5 @@
 <template>
   <div>
-    <Link path="index" name="一覧" />
-    <Link path="new" name="作成" />
     <div class="my-10"></div>
     <router-view></router-view>
   </div>

--- a/app/javascript/views/Contacts/Index.vue
+++ b/app/javascript/views/Contacts/Index.vue
@@ -1,5 +1,8 @@
 <template>
   <div>
+    <div class="ml-auto new-btn">
+      <Link path="/new" icon="mdi-plus" name="新規作成" />
+    </div>
     <h1 class="mb-10">メール一覧</h1>
     <template v-for="contact in contacts">
       <v-card :key="contact.id" class="px-4">
@@ -54,3 +57,9 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.new-btn {
+  width: 150px;
+}
+</style>

--- a/app/javascript/views/Contacts/New.vue
+++ b/app/javascript/views/Contacts/New.vue
@@ -12,6 +12,7 @@
       <FileField label="添付画像" @input="postImage = $event" />
       <Button value="作成" @click="onSubmit" />
       <div class="blank my-3"></div>
+      <router-link :to="{ path: 'index' }"><p style="padding-top: 15px;">変更をキャンセル</p></router-link>
     </v-form>
   </div>
 </template>

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -21,6 +21,10 @@ class Contact < ApplicationRecord
     sent_at&.strftime("%m月 %d日")
   end
 
+  def updated_at_formatted
+    updated_at&.strftime("%m月 %d日")
+  end
+
   def image
     contact_image&.image
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,10 @@ class User < ApplicationRecord
     following == community_center
   end
 
+  def initial
+    name[0].upcase
+  end
+
   private
 
     def downcase_email

--- a/app/views/api/v1/ads/index.json.jbuilder
+++ b/app/views/api/v1/ads/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @ads do |ad|
+  json.extract! ad, :id, :owner_name, :content, :phone_number, :url, :ad_image
+end

--- a/app/views/api/v1/community_centers/show.json.jbuilder
+++ b/app/views/api/v1/community_centers/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @community_center, :name, :comment
+json.extract! @community_center, :name, :comment, :user

--- a/app/views/api/v1/contacts/index.json.jbuilder
+++ b/app/views/api/v1/contacts/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @contacts do |contact|
-  json.extract! contact, :id, :subject, :content, :image, :sent_at_formatted, :now_processing
+  json.extract! contact, :id, :subject, :content, :image, :sent_at_formatted, :now_processing, :updated_at_formatted
 end

--- a/app/views/api/v1/users/index.json.jbuilder
+++ b/app/views/api/v1/users/index.json.jbuilder
@@ -1,0 +1,3 @@
+json.array! @users do |user|
+  json.extract! user, :id, :name, :email, :mute_contact, :initial
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,13 +13,13 @@ Rails.application.routes.draw do
       post '/contact_send/:id'       => 'contacts#mail'
 
       resources :account_activations, only: %i[edit]
-      resources :ads,                 only: %i[create]
+      resources :ads,                 only: %i[index create]
       resources :community_centers,   only: %i[index show create update destroy]
       resources :contacts,            only: %i[index show create update destroy]
-      resources :posts,               only: %i[show create update destroy]
+      resources :posts,               only: %i[index show create update destroy]
       resources :sessions,            only: %i[create]
       resources :timelines,           only: %i[index]
-      resources :users,               only: %i[show create update destroy]
+      resources :users,               only: %i[index show create update destroy]
     end
   end
   get '*path', to: 'home#index'


### PR DESCRIPTION
### 今まで管理者ページがTimeline.vueを置くだけの場所になっていましたが、管理画面にリニューアルしました

- トップページ管理者ページどちらからでも行えた投稿の「編集」「削除」を管理者ページに限定しています
- 管理者ページで、「投稿」「広告」「メール」「登録者（フォロワー）」の一覧を取得できるようにしています
- メールの編集、送信はメール管理画面からのみ行えます
- テストをしやすくするために、一旦広告の並び替えシャッフルをコメントアウトしています
- フロントの要求に伴って、Posts, Ads, Usersにindexのアクション、ビューを追加しています

- その他、いくつかUI修正を行っています。