### PR TITLE
メール認証省略、お知らせUI修正

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::SessionsController < ApiController
 
   def create
+    byebug
     hmac_secret = ENV['SECRET_KEY']
     @user = User.find_by!(email: params[:email])
     if @user.nil? || !@user.authenticate(params[:password])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -16,8 +16,10 @@ class Api::V1::UsersController < ApiController
     if @user.save
       community_center = CommunityCenter.find_by(name: params[:follow])
       @user.follow(community_center)
+      @user.notifications.create(title: 'ビズコミへようこそ！', content: '会員登録が完了しました。')
       community_center.user.notifications.create(title: 'お知らせ', content: '新しいユーザーが公民館を登録しました。')
-      @user.send_activation_email
+      # @user.send_activation_email
+      @user.activate
       response_success
     elsif @user.errors && @user.errors[:email][0] == 'has already been taken'
       response_conflict

--- a/app/javascript/components/Link.vue
+++ b/app/javascript/components/Link.vue
@@ -1,7 +1,8 @@
 <template>
   <v-btn
     @click="onClick"
-    class="white--text px-5 rounded"
+    rounded
+    class="white--text px-10 py-7"
     color="#243743">
     <v-icon v-show="!!icon" class="pr-3">{{ icon }}</v-icon>
     <p>{{ name }}</p>
@@ -12,13 +13,13 @@
 export default {
   props: {
     path: {
-      required: true
+      require: true
     },
     name: {
-      required: true
+      require: true
     },
     icon: {
-      required: false
+      require: false
     }
   },
   methods: {

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -18,6 +18,10 @@
       </v-list-item>
       <div class="nav-flex">
         <v-list class="mb-10" dense nav>
+          <v-list-item to="/help">
+            <v-list-item-icon><v-icon>mdi-help-circle-outline</v-icon></v-list-item-icon>
+            <v-list-item-content><v-list-item-title>ヘルプ</v-list-item-title></v-list-item-content>
+          </v-list-item>
           <v-list-item
             v-for="item in drawerItems"
             :key="item.name"
@@ -79,7 +83,7 @@
             <v-virtual-scroll
               :items="notifications"
               :item-height="90"
-              height="400">
+              height="250">
               <template v-slot:default="{ item }">
                 <v-list-item>
                   <v-list-item-avatar><img src="images/apple-touch-icon.png" alt=""></v-list-item-avatar>
@@ -146,6 +150,7 @@ export default {
       {
         name: 'ヘルプ',
         icon: 'mdi-help-circle-outline',
+        to: '/help',
         hideWhenLogin: false
       }
     ]
@@ -175,10 +180,15 @@ export default {
           icon: 'mdi-clipboard-plus-outline'
         }
       ]
+    },
+    route () {
+      return this.$route
     }
   },
-  mounted () {
-    this.getNotifications()
+  watch: {
+    route () {
+      this.getNotifications()
+    }
   },
   methods: {
     toTop () {
@@ -188,7 +198,7 @@ export default {
       location.reload()
     },
     getNotifications () {
-      if (!this.userId) {
+      if (this.loggedIn && !this.userId) {
         setTimeout(this.getNotifications, 1000)
       }
       this.$axios.get(`/notifications/${this.userId}`).then(res => {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -76,12 +76,13 @@ const actions = {
     }
   },
   // メール認証が送信されるため、responseは無し
-  signUp ({ commit }, data) {
+  signUp ({ commit, dispatch }, data) {
     commit('updateIsLoading', true)
     axios.post('/users', data).then(() => {
-      commit('updateSignedUp', true)
+      // commit('updateSignedUp', true)
       commit('updateIsLoading', false)
-      router.push('/')
+      // router.push('/')
+      dispatch('logIn', data.user)
     }).catch(err => {
       commit('updateIsLoading', false)
       // 409 Conflictのとき

--- a/app/javascript/stylesheets/styles.scss
+++ b/app/javascript/stylesheets/styles.scss
@@ -98,6 +98,7 @@
     font-size: 14px;
   }
   .top-menu {
+    flex-direction: column;
     .to-signup,
     .to-login {
       font-size: 14px !important;

--- a/app/javascript/views/Top.vue
+++ b/app/javascript/views/Top.vue
@@ -58,25 +58,25 @@
 
       <section id="introduction" class="my-10">
         <h2>カンタン！
-          <br>登録までの３ステップ
+          <br>登録までの２ステップ
         </h2>
         <v-container class="steps">
           <v-row>
-            <v-col cols=12 lg=4 class="step">
+            <v-col cols=12 lg=6 class="step">
               <v-img src="images/introduction/signup.jpg" class="step-img" contain />
               <h2 class="pb-4">新規登録</h2>
               <p>ニックネーム、メールアドレス、お住まいの地域の公民館を登録</p>
             </v-col>
-            <v-col cols=12 lg=4 class="step">
+            <!-- <v-col cols=12 lg=4 class="step">
               <v-img src="images/introduction/account_activation.jpg" class="step-img" contain />
               <h2 class="pb-4">メールを確認</h2>
               <p>登録したメールアドレスにメールが届いたメールからアカウントを有効化</p>
-            </v-col>
-            <v-col cols=12 lg=4 class="step">
+            </v-col> -->
+            <v-col cols=12 lg=6 class="step">
               <v-img src="images/introduction/views.jpg" class="step-img" contain />
               <h2 class="pb-4">登録完了！</h2>
-              <p>さっそくログインして、地域の情報をのぞいてみましょう！
-                <br>お得な情報が見つかるかも？
+              <p>地域の情報をのぞいてみよう！
+                <br>お得な情報が見つかるかも
               </p>
             </v-col>
           </v-row>
@@ -86,7 +86,7 @@
       <section id="get-started">
         <h3>はじめてみましょう！</h3>
         <br>
-        <Link path="/signup" name="利用者登録" />
+        <Link path="/signup" name="はじめる" />
         <div class="back">
           <p class="d-inline back">一番上に戻る</p><v-icon v-scroll-to="{ el: '#top-wrapper', offset: -80 }" x-large class="pa-3 scroll-icon">mdi-chevron-up</v-icon>
         </div>


### PR DESCRIPTION
- メール認証のプロセスを省略しています
  - users#createでuser.activateをはさんでいます
  - store/index.jsで、signUpからデータを引き継いでそのままlogInをdispatchしています
  - Topページのメール認証ステップを削除しています
- お知らせ
  - mountedではなく、computedに入れたroute = this.$routeを監視してgetNotificationを呼び出すことで、表示されないことを防いでいます
  - virtual scrollを実装してみやすくしています
  - アカウント作成時の通知を追加しています
- その他
  - Linkコンポーネント（トップページのログインなどのボタン）を大きくしてみやすくしています
  - ログイン前でもサイドバーにヘルプが追加されています（リンク先は未実装）