### PR TITLE
投稿にidがなく削除できないエラーを修正

### DIFF
--- a/app/javascript/components/Post.vue
+++ b/app/javascript/components/Post.vue
@@ -49,6 +49,7 @@ export default {
   props: {
     post: {
       default: () => ({
+        id: '',
         title: '',
         content: '',
         post_image: {

--- a/app/views/api/v1/posts/index.json.jbuilder
+++ b/app/views/api/v1/posts/index.json.jbuilder
@@ -1,3 +1,3 @@
 json.array! @posts do |post|
-  json.extract! post, :type, :title, :content, :post_image, :community_center_id
+  json.extract! post, :id, :type, :title, :content, :post_image, :community_center_id
 end


### PR DESCRIPTION
Post.vueでpropsのpostにデフォルトでpost.id: ''を入れて、indexのjbuilderでidを渡しました。