### PR TITLE
リンクの挙動修正、メールアドレス非表示

### DIFF
--- a/app/javascript/views/CommunityCenter.vue
+++ b/app/javascript/views/CommunityCenter.vue
@@ -10,6 +10,7 @@
     <section id="info" class="text-left ml-10 my-5">
       <h2 class="pb-3">{{ communityCenter.name }}</h2>
       <p>管理者：{{ userData.name }}</p>
+      <p>登録ユーザー数：{{ followersNumber }}</p>
     </section>
 
     <v-expansion-panels
@@ -118,7 +119,8 @@ export default {
     posts: [],
     ads: [],
     contacts: [],
-    followers: []
+    followers: [],
+    followersNumber: null
   }),
   computed: {
     ...mapGetters(['userData']),
@@ -135,6 +137,7 @@ export default {
     }).catch(() => {
       this.$router.push('/')
     })
+    this.getFollowers()
   },
   methods: {
     getPosts () {
@@ -155,6 +158,7 @@ export default {
     getFollowers () {
       this.$axios.get('/users').then(res => {
         this.followers = res.data
+        this.followersNumber = this.followers.length
       })
     }
   }

--- a/app/javascript/views/Redirect.vue
+++ b/app/javascript/views/Redirect.vue
@@ -8,7 +8,12 @@
 <script>
 export default {
   mounted () {
-    open('https://forms.gle/oQorFcWkQWwxrNrAA', '_blank')
+    let confirmation = confirm('【目安箱】新しいページでアンケートフォームを開いてもよろしいですか？')
+    if (confirmation) {
+      open('https://forms.gle/oQorFcWkQWwxrNrAA', '_blank')
+    } else {
+      this.$router.push('/')
+    }
   }
 }
 </script>


### PR DESCRIPTION
### リンクの挙動修正
サイドバーのメニューとして「目安箱」を追加する場合Navbar.vueの中で関数を実行できなかったので、Redirect.vueに遷移して、新しいタブで開くことへのconfirmを表示するやり方を採用しました

### メールアドレス非表示
今まで公民館ユーザーからは、登録者のメールアドレスが取得できるような仕様でしたが、現在テスト環境がオープンになっていてかつ誰でもログインできる都合上、セキュリティの観点からメールアドレスの表示をやめました。