### PR TITLE
登録者数取得API

### DIFF
--- a/app/decorators/community_center_decorator.rb
+++ b/app/decorators/community_center_decorator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CommunityCenterDecorator
+  def followers_number
+    followers.count
+  end
+end

--- a/app/javascript/components/Post.vue
+++ b/app/javascript/components/Post.vue
@@ -62,12 +62,10 @@
               @click="modal = false">閉じる</v-btn>
           </v-card-actions>
         </v-card>
-        <v-dialog v-model="zoomImage">
-          <v-card>
-            <v-icon @click="zoomImage = false">mdi-close-circle-outline</v-icon>
-            <v-img :src="imageUrl" contain max-height="500" />
-          </v-card>
-        </v-dialog>
+        <v-overlay v-if="zoomImage" @click="zoomImage = false">
+          <v-icon @click="zoomImage = false" x-large>mdi-close</v-icon>
+          <v-img :src="imageUrl" contain class="mx-auto zoom-image" />
+        </v-overlay>
       </v-dialog>
   </div>
 </template>
@@ -184,3 +182,15 @@ export default {
   }
 }
 </script>
+
+<style lang="scss" scoped>
+.zoom-image {
+  max-width: 90%;
+}
+
+@media screen and (min-width: 600px) {
+  .zoom-image {
+    max-width: 500px;
+  }
+}
+</style>

--- a/app/javascript/views/CommunityCenter.vue
+++ b/app/javascript/views/CommunityCenter.vue
@@ -10,7 +10,7 @@
     <section id="info" class="text-left ml-10 my-5">
       <h2 class="pb-3">{{ communityCenter.name }}</h2>
       <p>管理者：{{ userData.name }}</p>
-      <p>登録ユーザー数：{{ followersNumber }}</p>
+      <p>登録ユーザー数：{{ communityCenter.followers_number }}</p>
     </section>
 
     <v-expansion-panels
@@ -112,28 +112,20 @@ export default {
   data: () => ({
     communityCenter: {
       name: null,
-      comment: null
+      comment: null,
+      followers_number: null
     },
     panel: [],
     readonly: false,
     posts: [],
     ads: [],
     contacts: [],
-    followers: [],
-    followersNumber: null
+    followers: []
   }),
   computed: {
     ...mapGetters(['userData', 'isManager']),
     cid () {
       return this.$route.query.cid
-    },
-    followersComputed () {
-      let data
-      this.$axios.get('/users').then(res => {
-        data = res.data.length
-        console.log(res.data.length)
-      })
-      return data
     }
   },
   mounted () {
@@ -162,14 +154,6 @@ export default {
       if (this.isManager) {
         this.$axios.get('/contacts').then(res => {
           this.contacts = res.data
-        })
-      }
-    },
-    getFollowers () {
-      if (this.isManager) {
-        this.$axios.get('/users').then(res => {
-          this.followers = res.data
-          this.followersNumber = this.followers.length
         })
       }
     }

--- a/app/views/api/v1/community_centers/show.json.jbuilder
+++ b/app/views/api/v1/community_centers/show.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! @community_center, :name, :comment, :user
+json.extract! @community_center, :name, :comment, :user, :followers_number

--- a/spec/decorators/community_center_decorator_spec.rb
+++ b/spec/decorators/community_center_decorator_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CommunityCenterDecorator do
+  let(:community_center) { CommunityCenter.new.extend CommunityCenterDecorator }
+  subject { community_center }
+  it { should be_a CommunityCenter }
+end


### PR DESCRIPTION
- CommunutyCenterモデルにdecoratorを作成して，followersのレコード数を返すfollowers_numberを定義し，community_centers#showのjbuilderに:followers_numberを追加しました．
- 登録ユーザー数に，users#indexから算出した値を利用していましたが，レコード数以上のユーザー情報は不要なため，通信を避けてfollowers_numberによる表示に改めました．