### PR TITLE
post, adフォームでpreview実装

### DIFF
--- a/app/javascript/components/Ad.vue
+++ b/app/javascript/components/Ad.vue
@@ -1,13 +1,11 @@
 <template>
   <v-card
     class="mx-auto my-4 text-left"
-    max-width="374"
-  >
+    max-width="374">
 
     <v-img
       height="250"
-      :src="imageUrl"
-    ></v-img>
+      :src="imageUrl" />
 
     <v-card-title class="font-maru">{{ ad.owner_name }}</v-card-title>
     <v-divider></v-divider>

--- a/app/javascript/components/FileField.vue
+++ b/app/javascript/components/FileField.vue
@@ -5,7 +5,7 @@
       :label="label"
       clearable
       @change="onChange"></v-file-input>
-    <v-img :src="blobUrl" class="mb-5" max-height="150" width="150" contain></v-img>
+    <!-- <v-img :src="blobUrl" class="mb-5" max-height="150" width="150" contain></v-img> -->
   </div>
 </template>
 

--- a/app/javascript/components/Post.vue
+++ b/app/javascript/components/Post.vue
@@ -3,16 +3,15 @@
     <v-card
       class="mx-auto"
       max-width="600"
-      @click="openModal"
-    >
+      @click="openModal">
       <div class="tool-wrapper">
         <v-menu offset-y absolute right v-if="isManager && isManagePage">
           <template v-slot:activator="{ on, attrs }">
             <v-icon
               class="icon"
               v-bind="attrs"
-              v-on="on"
-            >mdi-dots-horizontal</v-icon>
+              v-on="on">mdi-dots-horizontal
+            </v-icon>
           </template>
           <v-list>
             <v-list-item @click="toEdit">編集</v-list-item>

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -91,7 +91,8 @@ const actions = {
       // 409 Conflictのとき
       if (err.response.status === 409) {
         alert('登録済みのメールアドレスです。ログインしてください。')
-      alert(err)
+      } else {
+        alert('認証に失敗しました。')
       }
     })
   },
@@ -142,8 +143,9 @@ const actions = {
       // 409 Conflictのとき
       if (err.status === 409) {
         alert('お使いのメールアドレスは既に管理者登録済みです。')
+      } else {
+        alert('エラーが発生しました。入力内容をお確かめの上、再度お試しください。')
       }
-      alert('エラーが発生しました。')
     })
   },
   editProfile ({ commit }, data) {

--- a/app/javascript/views/Guide.vue
+++ b/app/javascript/views/Guide.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-stepper v-model="e1">
+  <v-stepper v-model="s">
     <v-stepper-items>
       <v-stepper-content step="1" class="pa-0">
         <v-container class="stepper pa-0">
@@ -9,7 +9,7 @@
               <br>もりだくさん
             </p>
           </v-row>
-          <v-row class="navigation ma-0" @click="e1 = 2">
+          <v-row class="navigation ma-0" @click="s = 2">
             <p class="mx-auto pt-2">つぎへ</p>
           </v-row>
         </v-container>
@@ -23,7 +23,7 @@
               <br>最新情報まで
             </p>
           </v-row>
-          <v-row class="navigation ma-0" @click="e1 = 3">
+          <v-row class="navigation ma-0" @click="s = 3">
             <p class="mx-auto pt-2">つぎへ</p>
           </v-row>
         </v-container>
@@ -43,25 +43,25 @@
     </v-stepper-items>
     <v-stepper-header>
       <v-stepper-step
-        :complete="e1 > 1"
+        :complete="s > 1"
         step="1"
         color="#243743"
         class="step"
-        @click="e1 = 1" />
+        @click="s = 1" />
 
       <v-divider></v-divider>
 
       <v-stepper-step
-        :complete="e1 > 2"
+        :complete="s > 2"
         step="2"
         color="#243743"
         class="step"
-        @click="e1 = 2" />
+        @click="s = 2" />
 
       <v-divider></v-divider>
 
       <v-stepper-step
-        :complete="e1 > 3"
+        :complete="s > 3"
         step="3"
         color="#243743"
         class="step"
@@ -73,12 +73,12 @@
 <script>
 export default {
   data: () => ({
-    e1: 1
+    s: 1
   }),
   methods: {
     toThird () {
-      if (this.e1 !== 1) {
-        this.e1 = 3
+      if (this.s !== 1) {
+        this.s = 3
       }
     },
     toTop () {

--- a/app/javascript/views/NewAd.vue
+++ b/app/javascript/views/NewAd.vue
@@ -1,31 +1,60 @@
 <template>
-  <div class="ma-10 new-ad-container">
+  <v-stepper v-model="s">
     <h1 id="form-title">広告作成</h1>
-    <v-form class="form" ref="new_ad_form" @sumit.prevent>
-      <Input
-        label="広告を登録する公民館"
-        type="select"
-        multiple
-        :items="communityCenters"
-        @input="form.community_centers = $event" />
-      <Input
-        label="店舗名"
-        @input="form.owner_name = $event" />
-      <Input
-        label="ひとこと"
-        type="middle"
-        @input="form.content = $event" />
-      <Input
-        label="電話番号"
-        @input="form.phone_number = $event" />
-      <Input
-        label="リンクのURL"
-        @input="form.url = $event" />
-      <FileField label="添付画像" @input="postImage = $event" />
-      <Button value="登録" @click="onSubmit" />
-      <div class="blank my-3"></div>
-    </v-form>
-  </div>
+    <v-stepper-items>
+      <v-stepper-content step="1">
+        <v-form class="form" ref="new_ad_form" @sumit.prevent>
+          <Input
+            label="広告を登録する公民館"
+            type="select"
+            multiple
+            :items="communityCenters"
+            @input="form.community_centers = $event" />
+          <Input
+            label="店舗名"
+            @input="form.owner_name = $event" />
+          <Input
+            label="ひとこと"
+            type="middle"
+            @input="form.content = $event" />
+          <Input
+            label="電話番号"
+            @input="form.phone_number = $event" />
+          <Input
+            label="リンクのURL"
+            @input="form.url = $event" />
+          <FileField label="添付画像" @input="postImage = $event" />
+          <Button value="次へ" @click="check" />
+          <div class="blank my-3"></div>
+        </v-form>
+      </v-stepper-content>
+      <v-stepper-content step="2">
+        <h3>プレビュー</h3>
+        <v-card
+          class="mx-auto my-4 text-left"
+          max-width="374">
+
+          <v-img
+            height="250"
+            :src="blobUrl" />
+
+          <v-card-title class="font-maru">{{ form.owner_name }}</v-card-title>
+          <v-divider></v-divider>
+
+          <v-card-text class="font-maru">
+            <div>{{ form.content }}</div>
+          </v-card-text>
+          <v-card-text class="font-maru" v-if="form.phone_number">
+            <v-icon>mdi-phone</v-icon>
+            <a href="#">{{ form.phone_number}}</a>
+          </v-card-text>
+            <p class="ad-link py-3 font-maru text-center"><a :href="form.url">詳しくはこちら</a></p>
+        </v-card>
+        <Button value="登録" @click="onSubmit" />
+        <p @click="s = 1" class="blue--text my-5">作成画面に戻る</p>
+      </v-stepper-content>
+    </v-stepper-items>
+  </v-stepper>
 </template>
 
 <script>
@@ -42,9 +71,20 @@ export default {
     },
     communityCenters: [],
     postImage: null,
-    isLoading: false
+    isLoading: false,
+    s: 1
   }),
-  computed: mapGetters(['followingId']),
+  computed: {
+    ...mapGetters(['followingId']),
+    blobUrl () {
+      if (this.postImage) {
+        let image = this.postImage.get('image')
+        if (image) {
+          return window.URL.createObjectURL(image)
+        }
+      }
+    }
+  },
   mounted () {
     this.$axios.get('/community_centers').then(res => {
       for (let i = 0; i < res.data.length; i ++) {
@@ -54,16 +94,19 @@ export default {
   },
   methods: {
     ...mapMutations(['updateIsLoading']),
-    onSubmit () {
+    check () {
       if (this.$refs.new_ad_form.validate()) {
-        this.updateIsLoading(true)
-        this.$axios.post('/ads', this.form).then(() => {
-          this.attachImage()
-        }).catch(() => {
-          this.updateIsLoading(false)
-          alert('エラーが発生しました。')
-        })
+        this.s = 2
       }
+    },
+    onSubmit () {
+      this.updateIsLoading(true)
+      this.$axios.post('/ads', this.form).then(() => {
+        this.attachImage()
+      }).catch(() => {
+        this.updateIsLoading(false)
+        alert('エラーが発生しました。')
+      })
     },
     attachImage () {
       this.$axios.post(`/ad_image`, this.postImage).then(() => {

--- a/app/javascript/views/NewPost.vue
+++ b/app/javascript/views/NewPost.vue
@@ -1,24 +1,50 @@
 <template>
-  <div class="ma-10 new-post-container">
+  <v-stepper v-model="s">
     <h1 id="form-title">投稿作成</h1>
-    <v-form class="form" ref="new_post_form" @sumit.prevent>
-      <Input
-        label="投稿の種類"
-        type="select"
-        :items="types"
-        @input="form.type = $event" />
-      <Input
-        label="投稿の見出し"
-        @input="form.title = $event" />
-      <Input
-        label="本文"
-        type="textarea"
-        @input="form.content = $event" />
-      <FileField label="添付画像" @input="postImage = $event" />
-      <Button value="投稿" @click="onSubmit" />
-      <div class="blank my-3"></div>
-    </v-form>
-  </div>
+    <v-stepper-items>
+      <v-stepper-content step="1">
+        <v-form class="form" ref="new_post_form" @sumit.prevent>
+          <Input
+            label="投稿の種類"
+            type="select"
+            :items="types"
+            @input="form.type = $event" />
+          <Input
+            label="投稿の見出し"
+            @input="form.title = $event" />
+          <Input
+            label="本文"
+            type="textarea"
+            @input="form.content = $event" />
+          <FileField label="添付画像" @input="postImage = $event" />
+          <Button value="次へ" @click="check" />
+          <div class="blank my-3"></div>
+        </v-form>
+      </v-stepper-content>
+      <v-stepper-content step="2">
+        <h3>プレビュー</h3>
+        <v-card
+          elevation="10"
+          max-width="700"
+          max-height="800"
+          class="mx-auto text-left my-5">
+          <v-img
+            :src="blobUrl"
+            max-height="300"
+            class="modal-img" />
+          <v-card-title class="pb-5">{{ form.title }}</v-card-title>
+          <v-card-subtitle>{{ form.type }}</v-card-subtitle>
+          <v-divider class="pb-5" />
+          <v-card-text class="post-modal-content" style="white-space: pre-wrap;">
+            <p v-html="link_activated_content"></p>
+          </v-card-text>
+          <p class="date">ｘｘ月ｘｘ日</p>
+        </v-card>
+        <Button value="作成" @click="onSubmit" />
+        <p @click="s = 1" class="blue--text my-5">作成画面に戻る</p>
+      </v-stepper-content>
+    </v-stepper-items>
+  </v-stepper>
 </template>
 
 <script>
@@ -33,20 +59,24 @@ export default {
       content: ''
     },
     postImage: null,
-    requires: [ v => !!v || '必須項目です' ]
+    requires: [ v => !!v || '必須項目です' ],
+    s: 1
   }),
   methods: {
     ...mapMutations(['updateIsLoading']),
-    onSubmit () {
+    check () {
       if (this.$refs.new_post_form.validate()) {
-        this.updateIsLoading(true)
-        this.$axios.post('/posts', this.form).then(() => {
-          this.attachImage()
-        }).catch(() => {
-          this.updateIsLoading(false)
-          alert('情報に不備があります。再度お確かめください。')
-        })
+        this.s = 2
       }
+    },
+    onSubmit () {
+      this.updateIsLoading(true)
+      this.$axios.post('/posts', this.form).then(() => {
+        this.attachImage()
+      }).catch(() => {
+        this.updateIsLoading(false)
+        alert('情報に不備があります。再度お確かめください。')
+      })
     },
     attachImage () {
       this.$axios.post(`/post_image/${this.followingId}`, this.postImage).then(() => {
@@ -56,9 +86,25 @@ export default {
         this.isLoading = false
         alert('エラーが発生しました。')
       })
+    },
+    makeLink (url) { 
+      return '<a href="' + url + '" target="_blank">' + url + '</a>' 
     }
   },
-  computed: mapGetters(['followingId'])
+  computed: {
+    ...mapGetters(['followingId']),
+    link_activated_content () {
+      return this.form.content.replace(this.url_regex, this.makeLink)
+    },
+    blobUrl () {
+      if (this.postImage) {
+        let image = this.postImage.get('image')
+        if (image) {
+          return window.URL.createObjectURL(image)
+        }
+      }
+    }
+  }
 }
 </script>
 

--- a/app/javascript/views/SignUp.vue
+++ b/app/javascript/views/SignUp.vue
@@ -105,9 +105,13 @@ export default {
     onSubmit () {
       this.showAlert.term = this.showAlert.password = false
       // 利用規約とパスワードについては，ルールとは別途アラート
-      if (!this.agree) { this.showAlert.term = true }
-      if (!this.samePass) {
-        this.showAlert.password = true
+      if (!this.agree || !this.samePass) {
+        if (!this.agree) {
+          this.showAlert.term = true
+        }
+        if (!this.samePass) {
+          this.showAlert.password = true
+        }
       } else if (this.$refs.signup_form.validate()) {
         let confirmation = confirm(`登録する公民館は「${this.follow}」でお間違いありませんか？`)
         if (!confirmation) { return }


### PR DESCRIPTION
- v-stepperを利用して，postとadのフォームにプレビュー（確認画面）を実装しています．
- バリデーションは，一つ目の画面で「次へ」をクリック時に全体に走ります．
- バリデーションを通過した場合，次のページで実際の表示と同じものが表示され，postなら「作成」，adなら「登録」をclickでこれまで同様にレコードが作成されます．